### PR TITLE
Disregard internal href

### DIFF
--- a/ambariclient/base.py
+++ b/ambariclient/base.py
@@ -590,9 +590,11 @@ class QueryableModel(Model):
         Otherwise, it will generated it based on the collection's url and the
         model's identifier.
         """
-        if self._href is not None:
-            return self._href
+        # if self._href is not None:
+        #     return self._href
         if self.identifier:
+            if self.identifier == 'Unknown':
+                return self.parent.url
             return '/'.join([self.parent.url, self.identifier])
         raise exceptions.ClientError("Not able to determine object URL")
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ with open(requirements_path) as requirements_file:
 
 setuptools.setup(
     name="python-ambariclient",
-    version="0.6.0",
+    version="0.6.1",
     author="Rackspace",
     author_email="greg.hill@rackspace.com",
     description="Client library for Apache Ambari.",


### PR DESCRIPTION
### Summary
The API client errors when trying to access nested resources.  This happens because each resource has an HREF resource url attached to it but this resource url is based on an internal hostname which isn't accessible in Azure.

This PR makes the host url based on parent's hostname.